### PR TITLE
Create an index on the title as well.

### DIFF
--- a/fields/field.pages.php
+++ b/fields/field.pages.php
@@ -89,8 +89,9 @@
 				  `handle` varchar(255) default NULL,
 				  PRIMARY KEY  (`id`),
 				  KEY `entry_id` (`entry_id`),
-				  KEY `handle` (`handle`),
-				  KEY `page_id` (`page_id`)
+				  KEY `page_id` (`page_id`),
+				  KEY `title` (`title`),
+				  KEY `handle` (`handle`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;"
 			);
 		}


### PR DESCRIPTION
When filtering on a Page Select Box, Symphony creates queries like

``` sql
... AND (`t1225`.page_id IN ('My Page') OR `t1225`.handle IN ('My Page') OR `t1225`.title IN ('My Page') …`
```

so it can't be bad to have an index on the `title`as well.
